### PR TITLE
fix(ads): GAM 2s consent timeout + non-personalized fallback (86c98hx43)

### DIFF
--- a/store/ads.js
+++ b/store/ads.js
@@ -1009,6 +1009,20 @@ export const actions = {
     window.googlefc.callbackQueue = window.googlefc.callbackQueue || []
     window.googletag = window.googletag || {}
     window.googletag.cmd = window.googletag.cmd || []
+
+    // 2s safety timeout: if CONSENT chain does not resolve
+    // (CONSENT_API_READY never fires, __tcfapi never callbacks, Safari ITP),
+    // serve non-personalized ads as GDPR-compliant fallback (CU-86c98hx43)
+    setTimeout(() => {
+      if (window.pbjs.requestManager.adServerRequestSent) return
+      window.googletag.cmd.push(function () {
+        window.googletag
+          .pubads()
+          .setPrivacySettings({ restrictDataProcessing: true })
+      })
+      dispatch('initAdserver')
+    }, 2000)
+
     /* global __tcfapi */
     window.googlefc.callbackQueue.push({
       CONSENT_API_READY: () =>


### PR DESCRIPTION
Manual cherry-pick samo GAM 2s fixa iz `origin/staging` (`d64cad4b` + `10638b93`). NE uključuje Learn More AI Q&A ni druge staging stvari.

Replaces #165.

**Diff:** +14 linija u `store/ads.js` (consent fallback setTimeout blok unutar `refreshSlots` action-a).

CU: https://app.clickup.com/t/86c98hx43