### PR TITLE
fix(ads): close button -48px desktop / -60px mobile via CSS variable (86c94y70h)

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -12599,34 +12599,30 @@ html.large-fontsize,
 
 /* Ticker and takeover exit buttons */
 
-.sticky-banner .ticker-exit {
+.sticky-banner .ticker-exit,
+.sticky-banner .takeover-exit,
+.sticky-banner .ticker-right-exit {
+    --close-size: 48px;
     position: absolute;
-    right: -23px;
-    left: auto;
-    top: -23px;
-    z-index: 201;
-}
-
-.sticky-banner .takeover-exit {
-    position: absolute;
-    right: -23px;
-    left: auto;
-    top: -23px;
+    width: var(--close-size);
+    height: var(--close-size);
+    font-size: var(--close-size);
+    line-height: 1;
+    top: calc(-1 * var(--close-size));
+    right: calc(-1 * var(--close-size));
     z-index: 201;
 }
 
 .sticky-banner .ticker-right-exit {
-    position: absolute;
-    left: -23px;
     right: auto;
-    top: -23px;
-    z-index: 201;
+    left: calc(-1 * var(--close-size));
 }
 
-@media screen and (max-height: 767px) {
-    .sticky-banner .takeover-exit {
-        right: 8px;
-        top: 8px;
+@media screen and (max-width: 480px) {
+    .sticky-banner .ticker-exit,
+    .sticky-banner .takeover-exit,
+    .sticky-banner .ticker-right-exit {
+        --close-size: 60px;
     }
 }
 

--- a/components/Elements/TickerAdUnit.vue
+++ b/components/Elements/TickerAdUnit.vue
@@ -28,7 +28,6 @@
             @click.prevent="shouldHide = true"
             ><font-awesome-icon
               :icon="['fas', 'times-circle']"
-              size="3x"
               style="color: #ae3736"
             ></font-awesome-icon
           ></a>


### PR DESCRIPTION
## Summary
- Konsolidira .ticker-exit / .takeover-exit / .ticker-right-exit u jedno pravilo s --close-size CSS variable
- Desktop: --close-size 48px (offset matches FA icon size)
- Mobile <=480px: --close-size 60px (veći touch target)
- Uklanja size="3x" prop iz TickerAdUnit.vue, veličina sada curi iz CSS-a
- Eliminira mobile takeover-exit "8px/8px UNUTRA" override koji je bio GAM compliance rizik

## ClickUp
86c94y70h — https://app.clickup.com/t/86c94y70h

## Test plan
- [ ] Desktop > 1248px: ticker/takeover X gore-desno na -48px, ne overlapa AdChoices
- [ ] Tablet 640-1248px: ticker centered (left:50%), bez regresije
- [ ] Mobile 481-767px: X na -60px (proporcionalno za 60px ikonu)
- [ ] Mobile <=480px: X na -60px van creative-a, ne UNUTRA kao prije
- [ ] X je sibling od #telegram_sticky, nije child od ad iframe-a (GAM compliance)