### PR TITLE
feat: add HT AI Kalkulator popup component

### DIFF
--- a/components/ht-kalkulator/HtKalkulator.vue
+++ b/components/ht-kalkulator/HtKalkulator.vue
@@ -1,5 +1,11 @@
 <template>
-  <div v-if="visible" class="ht-kalkulator-overlay" @keydown.esc="handleEsc">
+  <div
+    v-if="visible"
+    class="ht-kalkulator-overlay"
+    @click.self="handleDismiss"
+    @keydown.esc="handleEsc"
+    @keydown.tab="handleTab"
+  >
     <div
       ref="wrapper"
       class="ht-kalkulator"
@@ -48,6 +54,9 @@ import {
   calculateResults,
 } from '~/store/ht-kalkulator/data'
 
+const FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
 export default {
   name: 'HtKalkulator',
   data() {
@@ -70,11 +79,15 @@ export default {
       this.visible = false
       return
     }
+    document.body.style.overflow = 'hidden'
     this.$nextTick(() => {
       if (this.$refs.wrapper) {
         this.$refs.wrapper.focus()
       }
     })
+  },
+  beforeDestroy() {
+    document.body.style.overflow = ''
   },
   methods: {
     handleStart() {
@@ -115,6 +128,7 @@ export default {
     handleDismiss() {
       this.setStoredState('dismissed')
       this.visible = false
+      document.body.style.overflow = ''
     },
 
     handleRestart() {
@@ -141,6 +155,22 @@ export default {
     handleEnter() {
       if (this.state === 'intro') {
         this.handleStart()
+      }
+    },
+
+    handleTab(e) {
+      const wrapper = this.$refs.wrapper
+      if (!wrapper) return
+      const focusable = [...wrapper.querySelectorAll(FOCUSABLE)]
+      if (!focusable.length) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
       }
     },
 
@@ -178,22 +208,23 @@ export default {
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 99;
+  z-index: 10100;
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 20px;
-  pointer-events: none;
 }
 
 .ht-kalkulator {
   width: 100%;
   max-width: 640px;
+  max-height: 90vh;
+  overflow-y: auto;
   background: #fff;
   border-radius: 16px;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
   position: relative;
-  pointer-events: auto;
 }
 
 .ht-kalkulator:focus {

--- a/components/ht-kalkulator/HtKalkulator.vue
+++ b/components/ht-kalkulator/HtKalkulator.vue
@@ -1,0 +1,236 @@
+<template>
+  <div v-if="visible" class="ht-kalkulator-overlay" @keydown.esc="handleEsc">
+    <div
+      ref="wrapper"
+      class="ht-kalkulator"
+      role="dialog"
+      aria-modal="true"
+      aria-label="HT AI Kalkulator"
+      tabindex="-1"
+      @keydown.enter="handleEnter"
+    >
+      <button
+        class="ht-kalkulator-close"
+        aria-label="Zatvori"
+        @click="handleDismiss"
+      >
+        &times;
+      </button>
+
+      <ht-kalkulator-intro
+        v-if="state === 'intro'"
+        @start="handleStart"
+        @dismiss="handleDismiss"
+      />
+
+      <ht-kalkulator-question
+        v-if="state === 'questions'"
+        :key="currentQuestion.id"
+        :question="currentQuestion"
+        :question-index="answers.length + 1"
+        :total-questions="questions.length"
+        @answer="handleAnswer"
+      />
+
+      <ht-kalkulator-result
+        v-if="state === 'result'"
+        :results="results"
+        @restart="handleRestart"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  QUESTIONS,
+  STORAGE_KEY,
+  calculateResults,
+} from '~/store/ht-kalkulator/data'
+
+export default {
+  name: 'HtKalkulator',
+  data() {
+    return {
+      state: 'intro',
+      visible: true,
+      questions: QUESTIONS,
+      answers: [],
+      results: null,
+    }
+  },
+  computed: {
+    currentQuestion() {
+      return this.questions[this.answers.length] || this.questions[0]
+    },
+  },
+  mounted() {
+    const stored = this.getStoredState()
+    if (stored === 'dismissed' || stored === 'completed') {
+      this.visible = false
+      return
+    }
+    this.$nextTick(() => {
+      if (this.$refs.wrapper) {
+        this.$refs.wrapper.focus()
+      }
+    })
+  },
+  methods: {
+    handleStart() {
+      this.state = 'questions'
+      this.answers = []
+      this.results = null
+      this.$gtm.push({ event: 'ht-kalkulator-start' })
+    },
+
+    handleAnswer(answer) {
+      this.answers.push(answer)
+
+      this.$gtm.push({
+        event: 'ht-kalkulator-question',
+        kalkulator_question: answer.questionId,
+        kalkulator_answer_minutes: answer.minutes,
+      })
+
+      if (this.answers.length === this.questions.length) {
+        this.showResults()
+      }
+    },
+
+    showResults() {
+      this.results = calculateResults(this.answers)
+      this.state = 'result'
+
+      this.setStoredState('completed')
+
+      this.$gtm.push({
+        event: 'ht-kalkulator-complete',
+        kalkulator_total_hours_weekly: this.results.totalHoursWeekly,
+        kalkulator_total_hours_monthly: this.results.totalHoursMonthly,
+        kalkulator_savings_hours_monthly: this.results.savedHoursMonthly,
+      })
+    },
+
+    handleDismiss() {
+      this.setStoredState('dismissed')
+      this.visible = false
+    },
+
+    handleRestart() {
+      this.state = 'intro'
+      this.answers = []
+      this.results = null
+      this.removeStoredState()
+
+      this.$nextTick(() => {
+        if (this.$refs.wrapper) {
+          this.$refs.wrapper.focus()
+        }
+      })
+    },
+
+    handleEsc() {
+      if (this.state === 'questions') {
+        this.handleRestart()
+      } else {
+        this.handleDismiss()
+      }
+    },
+
+    handleEnter() {
+      if (this.state === 'intro') {
+        this.handleStart()
+      }
+    },
+
+    getStoredState() {
+      try {
+        return localStorage.getItem(STORAGE_KEY)
+      } catch {
+        return null
+      }
+    },
+
+    setStoredState(value) {
+      try {
+        localStorage.setItem(STORAGE_KEY, value)
+      } catch {
+        // localStorage unavailable
+      }
+    },
+
+    removeStoredState() {
+      try {
+        localStorage.removeItem(STORAGE_KEY)
+      } catch {
+        // localStorage unavailable
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+.ht-kalkulator-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 99;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  pointer-events: none;
+}
+
+.ht-kalkulator {
+  width: 100%;
+  max-width: 640px;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
+  position: relative;
+  pointer-events: auto;
+}
+
+.ht-kalkulator:focus {
+  outline: none;
+}
+
+.ht-kalkulator-close {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 10;
+  background: none;
+  border: none;
+  font-size: 28px;
+  line-height: 1;
+  color: #999;
+  cursor: pointer;
+  padding: 4px 8px;
+  transition: color 0.2s;
+}
+
+.ht-kalkulator-close:hover {
+  color: #333;
+}
+
+.ht-kalkulator-close:focus-visible {
+  outline: 3px solid #e20074;
+  outline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  .ht-kalkulator-overlay {
+    padding: 10px;
+  }
+
+  .ht-kalkulator {
+    border-radius: 12px;
+  }
+}
+</style>

--- a/components/ht-kalkulator/HtKalkulatorIntro.vue
+++ b/components/ht-kalkulator/HtKalkulatorIntro.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="ht-kalkulator-intro">
+    <h2 class="ht-kalkulator-intro-title">
+      Koliko vremena gubite na zadatke koje AI može obaviti umjesto vas?
+    </h2>
+    <p class="ht-kalkulator-intro-description">
+      Odgovorite na 6 kratkih pitanja i saznajte koliko sati mjesečno možete
+      uštedjeti uz pomoć umjetne inteligencije.
+    </p>
+    <button class="ht-kalkulator-intro-cta" @click="$emit('start')">
+      Kreni
+    </button>
+    <button class="ht-kalkulator-intro-dismiss" @click="$emit('dismiss')">
+      Ne zanima me
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HtKalkulatorIntro',
+}
+</script>
+
+<style scoped>
+.ht-kalkulator-intro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 48px 24px;
+}
+
+.ht-kalkulator-intro-title {
+  font-family: 'Lora', serif;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--tg-primary-text-color, #111);
+  margin-bottom: 16px;
+  max-width: 480px;
+}
+
+.ht-kalkulator-intro-description {
+  font-family: 'Barlow', sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #555;
+  margin-bottom: 32px;
+  max-width: 420px;
+}
+
+.ht-kalkulator-intro-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 48px;
+  background: #e20074;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Barlow', sans-serif;
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+  margin-bottom: 16px;
+}
+
+.ht-kalkulator-intro-cta:hover {
+  background: #c80066;
+}
+
+.ht-kalkulator-intro-cta:focus-visible {
+  outline: 3px solid #e20074;
+  outline-offset: 2px;
+}
+
+.ht-kalkulator-intro-dismiss {
+  background: none;
+  border: none;
+  font-family: 'Barlow', sans-serif;
+  font-size: 14px;
+  color: #999;
+  cursor: pointer;
+  padding: 8px 16px;
+  transition: color 0.2s;
+}
+
+.ht-kalkulator-intro-dismiss:hover {
+  color: #666;
+}
+
+@media (max-width: 768px) {
+  .ht-kalkulator-intro {
+    padding: 32px 16px;
+  }
+
+  .ht-kalkulator-intro-title {
+    font-size: 20px;
+  }
+
+  .ht-kalkulator-intro-cta {
+    width: 100%;
+    padding: 14px 24px;
+  }
+}
+</style>

--- a/components/ht-kalkulator/HtKalkulatorProgress.vue
+++ b/components/ht-kalkulator/HtKalkulatorProgress.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="ht-kalkulator-progress" aria-hidden="true">
+    <span class="ht-kalkulator-progress-current">{{ current }}</span>
+    <span class="ht-kalkulator-progress-separator">/</span>
+    <span class="ht-kalkulator-progress-total">{{ total }}</span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HtKalkulatorProgress',
+  props: {
+    current: {
+      type: Number,
+      required: true,
+    },
+    total: {
+      type: Number,
+      required: true,
+    },
+  },
+}
+</script>
+
+<style scoped>
+.ht-kalkulator-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  background: #f5f5f5;
+  font-family: 'Barlow', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #666;
+}
+
+.ht-kalkulator-progress-current {
+  color: #e20074;
+}
+</style>

--- a/components/ht-kalkulator/HtKalkulatorQuestion.vue
+++ b/components/ht-kalkulator/HtKalkulatorQuestion.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="ht-kalkulator-question">
+    <div class="ht-kalkulator-question-header">
+      <ht-kalkulator-progress
+        :current="questionIndex"
+        :total="totalQuestions"
+      />
+    </div>
+    <h3 class="ht-kalkulator-question-title">{{ question.title }}</h3>
+    <div
+      class="ht-kalkulator-question-options"
+      role="radiogroup"
+      :aria-label="question.title"
+    >
+      <button
+        v-for="(option, idx) in question.options"
+        :key="idx"
+        class="ht-kalkulator-option"
+        :class="{ 'ht-kalkulator-option-selected': selectedIndex === idx }"
+        role="radio"
+        :aria-checked="selectedIndex === idx ? 'true' : 'false'"
+        @click="selectOption(idx)"
+      >
+        <span class="ht-kalkulator-option-text">{{ option.label }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HtKalkulatorQuestion',
+  props: {
+    question: {
+      type: Object,
+      required: true,
+    },
+    questionIndex: {
+      type: Number,
+      required: true,
+    },
+    totalQuestions: {
+      type: Number,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      selectedIndex: -1,
+    }
+  },
+  methods: {
+    selectOption(idx) {
+      this.selectedIndex = idx
+      const option = this.question.options[idx]
+      this.$emit('answer', {
+        questionId: this.question.id,
+        minutes: option.minutes,
+        label: option.label,
+      })
+    },
+  },
+}
+</script>
+
+<style scoped>
+.ht-kalkulator-question {
+  padding: 32px 24px;
+}
+
+.ht-kalkulator-question-header {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 24px;
+}
+
+.ht-kalkulator-question-title {
+  font-family: 'Lora', serif;
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--tg-primary-text-color, #111);
+  margin-bottom: 24px;
+}
+
+.ht-kalkulator-question-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ht-kalkulator-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 14px 18px;
+  background: #fff;
+  border: 2px solid #e8e8e8;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: left;
+  font-family: 'Barlow', sans-serif;
+  font-size: 15px;
+  line-height: 1.4;
+  color: var(--tg-primary-text-color, #111);
+}
+
+.ht-kalkulator-option:hover {
+  border-color: #e20074;
+  background: #fef5fa;
+}
+
+.ht-kalkulator-option:focus-visible {
+  outline: 3px solid #e20074;
+  outline-offset: 2px;
+}
+
+.ht-kalkulator-option-selected {
+  border-color: #e20074;
+  background: #e20074;
+  color: #fff;
+}
+
+.ht-kalkulator-option-selected:hover {
+  background: #c80066;
+  border-color: #c80066;
+}
+
+@media (max-width: 768px) {
+  .ht-kalkulator-question {
+    padding: 24px 16px;
+  }
+
+  .ht-kalkulator-question-title {
+    font-size: 18px;
+  }
+
+  .ht-kalkulator-option {
+    padding: 12px 14px;
+    font-size: 14px;
+  }
+}
+</style>

--- a/components/ht-kalkulator/HtKalkulatorResult.vue
+++ b/components/ht-kalkulator/HtKalkulatorResult.vue
@@ -77,8 +77,16 @@ export default {
       required: true,
     },
   },
+  data() {
+    return {
+      rafIds: [],
+    }
+  },
   mounted() {
     this.animateNumbers()
+  },
+  beforeDestroy() {
+    this.rafIds.forEach((id) => cancelAnimationFrame(id))
   },
   methods: {
     animateNumbers() {
@@ -103,11 +111,11 @@ export default {
           : Math.round(current).toString()
 
         if (progress < 1) {
-          requestAnimationFrame(step)
+          this.rafIds.push(requestAnimationFrame(step))
         }
       }
 
-      requestAnimationFrame(step)
+      this.rafIds.push(requestAnimationFrame(step))
     },
   },
 }

--- a/components/ht-kalkulator/HtKalkulatorResult.vue
+++ b/components/ht-kalkulator/HtKalkulatorResult.vue
@@ -1,0 +1,253 @@
+<template>
+  <div class="ht-kalkulator-result" aria-live="polite">
+    <div class="ht-kalkulator-result-header">
+      <svg
+        width="48"
+        height="48"
+        viewBox="0 0 48 48"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="24" cy="24" r="24" fill="#FDE8F3" />
+        <path
+          d="M24 12a12 12 0 100 24 12 12 0 000-24zm-1.5 17.5l-4.5-4.5 1.4-1.4 3.1 3.1 6.1-6.1 1.4 1.4-7.5 7.5z"
+          fill="#e20074"
+        />
+      </svg>
+      <h3 class="ht-kalkulator-result-title">Vaši rezultati</h3>
+    </div>
+
+    <div class="ht-kalkulator-result-cards">
+      <div class="ht-kalkulator-result-card">
+        <span class="ht-kalkulator-result-label">Trenutno trošite</span>
+        <span class="ht-kalkulator-result-value">
+          <span ref="weeklyValue" class="ht-kalkulator-result-number">0</span>
+          <span class="ht-kalkulator-result-unit">sati tjedno</span>
+        </span>
+      </div>
+
+      <div class="ht-kalkulator-result-card">
+        <span class="ht-kalkulator-result-label">Mjesečno to je</span>
+        <span class="ht-kalkulator-result-value">
+          <span ref="monthlyValue" class="ht-kalkulator-result-number">0</span>
+          <span class="ht-kalkulator-result-unit">sati mjesečno</span>
+        </span>
+      </div>
+
+      <div
+        class="ht-kalkulator-result-card ht-kalkulator-result-card-highlight"
+      >
+        <span class="ht-kalkulator-result-label">Uz AI možete uštedjeti</span>
+        <span class="ht-kalkulator-result-value">
+          <span
+            ref="savingsValue"
+            class="ht-kalkulator-result-number ht-kalkulator-result-number-highlight"
+            >0</span
+          >
+          <span class="ht-kalkulator-result-unit">sati mjesečno</span>
+        </span>
+        <span class="ht-kalkulator-result-phrase"
+          >To je {{ results.dynamicPhrase }} radnog vremena!</span
+        >
+      </div>
+    </div>
+
+    <div class="ht-kalkulator-result-cta-placeholder">
+      <!-- Placeholder za HT CTA kad dizajn stigne -->
+    </div>
+
+    <p class="ht-kalkulator-result-disclaimer">
+      Procjene uštede temelje se na industrijskim prosjecima (McKinsey, GitHub,
+      Microsoft Work Trend).
+    </p>
+
+    <button class="ht-kalkulator-result-restart" @click="$emit('restart')">
+      Ponovi kalkulator
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HtKalkulatorResult',
+  props: {
+    results: {
+      type: Object,
+      required: true,
+    },
+  },
+  mounted() {
+    this.animateNumbers()
+  },
+  methods: {
+    animateNumbers() {
+      this.animateValue(this.$refs.weeklyValue, this.results.totalHoursWeekly)
+      this.animateValue(this.$refs.monthlyValue, this.results.totalHoursMonthly)
+      this.animateValue(this.$refs.savingsValue, this.results.savedHoursMonthly)
+    },
+    animateValue(el, target) {
+      if (!el) return
+      const duration = 1200
+      const startTime = performance.now()
+      const isDecimal = target % 1 !== 0
+
+      const step = (currentTime) => {
+        const elapsed = currentTime - startTime
+        const progress = Math.min(elapsed / duration, 1)
+        const eased = 1 - Math.pow(1 - progress, 3)
+        const current = eased * target
+
+        el.textContent = isDecimal
+          ? current.toFixed(1)
+          : Math.round(current).toString()
+
+        if (progress < 1) {
+          requestAnimationFrame(step)
+        }
+      }
+
+      requestAnimationFrame(step)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.ht-kalkulator-result {
+  padding: 32px 24px;
+  text-align: center;
+}
+
+.ht-kalkulator-result-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.ht-kalkulator-result-title {
+  font-family: 'Lora', serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--tg-primary-text-color, #111);
+}
+
+.ht-kalkulator-result-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.ht-kalkulator-result-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
+  background: #f9f9f9;
+  border-radius: 12px;
+  border: 1px solid #eee;
+}
+
+.ht-kalkulator-result-card-highlight {
+  background: #fef5fa;
+  border-color: #e20074;
+  border-width: 2px;
+}
+
+.ht-kalkulator-result-label {
+  font-family: 'Barlow', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #777;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.ht-kalkulator-result-value {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.ht-kalkulator-result-number {
+  font-family: 'Poppins', sans-serif;
+  font-size: 40px;
+  font-weight: 700;
+  color: var(--tg-primary-text-color, #111);
+  line-height: 1;
+}
+
+.ht-kalkulator-result-number-highlight {
+  color: #e20074;
+}
+
+.ht-kalkulator-result-unit {
+  font-family: 'Barlow', sans-serif;
+  font-size: 16px;
+  color: #666;
+}
+
+.ht-kalkulator-result-phrase {
+  font-family: 'Barlow', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: #e20074;
+  margin-top: 8px;
+}
+
+.ht-kalkulator-result-cta-placeholder {
+  min-height: 0;
+}
+
+.ht-kalkulator-result-disclaimer {
+  font-family: 'Barlow', sans-serif;
+  font-size: 12px;
+  color: #999;
+  line-height: 1.4;
+  margin-bottom: 24px;
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ht-kalkulator-result-restart {
+  background: none;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 10px 24px;
+  font-family: 'Barlow', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #666;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.ht-kalkulator-result-restart:hover {
+  border-color: #e20074;
+  color: #e20074;
+}
+
+.ht-kalkulator-result-restart:focus-visible {
+  outline: 3px solid #e20074;
+  outline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  .ht-kalkulator-result {
+    padding: 24px 16px;
+  }
+
+  .ht-kalkulator-result-number {
+    font-size: 32px;
+  }
+
+  .ht-kalkulator-result-title {
+    font-size: 20px;
+  }
+}
+</style>

--- a/pages/_category/_slug.vue
+++ b/pages/_category/_slug.vue
@@ -439,6 +439,9 @@
                 @click="handleClick"
                 v-html="post.content"
               ></div>
+              <client-only>
+                <ht-kalkulator v-if="showKalkulator" />
+              </client-only>
               <!-- AI-generated summary pinned above live updates -->
               <article
                 v-if="post.live && post.live_summary"
@@ -1212,6 +1215,7 @@ import StudenacWidget from '~/components/Elements/StudenacWidget.vue'
 import A1Widget from '~/components/Elements/A1Widget.vue'
 import HtWidget from '~/components/Elements/HtWidget.vue'
 import BusinessWidget from '~/components/Elements/BusinessWidget.vue'
+import HtKalkulator from '~/components/ht-kalkulator/HtKalkulator.vue'
 
 const widgetMap = {
   studenac: 'StudenacWidget',
@@ -1223,7 +1227,7 @@ const widgetMap = {
 export default {
   name: 'Slug',
   scrollToTop: true,
-  components: { Portal, StudenacWidget, A1Widget, HtWidget, BusinessWidget },
+  components: { Portal, StudenacWidget, A1Widget, HtWidget, BusinessWidget, HtKalkulator },
   async fetch() {
     if (!this.$route.params.slug && !this.$route.params.category) {
       return
@@ -1287,6 +1291,7 @@ export default {
       single_title: '',
       showMidasIntext: false,
       showQuiz: false,
+      showKalkulator: false,
       comments: false,
       comments_embed: null,
       showSideMenu: false,
@@ -1914,6 +1919,9 @@ export default {
         }
         if (this.post.quiz) {
           this.showQuiz = true
+        }
+        if (this.$route.query['ht-kalkulator'] === '1') {
+          this.showKalkulator = true
         }
         this.$store.commit('history/setData', this.post)
         this.triggerAnalytics()

--- a/store/ht-kalkulator/data.js
+++ b/store/ht-kalkulator/data.js
@@ -1,0 +1,123 @@
+export const QUESTIONS = [
+  {
+    id: 1,
+    category: 'email',
+    title:
+      'Koliko vremena tjedno potrošiš na čitanje, odgovaranje i pretraživanje emailova i poruka (WhatsApp, Slack, Teams…)?',
+    aiSavingsPercent: 0.3,
+    options: [
+      { label: 'Samo brzinski, tu i tamo — do 30 min tjedno', minutes: 15 },
+      { label: 'Malo svaki dan — 30–60 min tjedno', minutes: 45 },
+      { label: 'Većinu tjedna — 1–3 sata tjedno', minutes: 120 },
+      { label: 'Prilično puno vremena — 3–5 sati tjedno', minutes: 240 },
+      { label: 'To mi je ozbiljan dio posla — 5–10 sati tjedno', minutes: 450 },
+      {
+        label: 'Imam osjećaj da stalno odgovaram — 10+ sati tjedno',
+        minutes: 720,
+      },
+    ],
+  },
+  {
+    id: 2,
+    category: 'pisanje',
+    title:
+      'Koliko vremena trošiš na pisanje mailova, ponuda, izvještaja, prezentacija ili članaka?',
+    aiSavingsPercent: 0.4,
+    options: [
+      { label: 'Manji dio radnog dana', minutes: 45 },
+      { label: 'Prilično puno vremena', minutes: 240 },
+      { label: 'To mi je ozbiljan dio posla', minutes: 450 },
+      { label: 'Praktički stalno nešto pišem', minutes: 720 },
+    ],
+  },
+  {
+    id: 3,
+    category: 'admin',
+    title:
+      'Koliko vremena tjedno potrošiš na administraciju, tablice, unos podataka i traženje dokumenata?',
+    aiSavingsPercent: 0.35,
+    options: [
+      { label: 'Samo osnovno kad moram', minutes: 15 },
+      { label: 'Većinu tjedna', minutes: 120 },
+      { label: 'Prilično puno vremena', minutes: 240 },
+      { label: 'To mi je velik dio posla', minutes: 450 },
+      { label: 'Osjećam se kao da sam stalno u Excelu', minutes: 720 },
+    ],
+  },
+  {
+    id: 4,
+    category: 'istrazivanje',
+    title:
+      'Koliko vremena provedeš tražeći informacije na Googleu ili kroz dokumente i mailove?',
+    aiSavingsPercent: 0.45,
+    options: [
+      { label: 'Rijetko i kratko', minutes: 15 },
+      { label: 'Manje od 1 sata tjedno', minutes: 45 },
+      { label: 'Prilično puno vremena', minutes: 240 },
+      { label: 'To mi je čest zadatak', minutes: 450 },
+      { label: 'Stalno nešto istražujem', minutes: 720 },
+    ],
+  },
+  {
+    id: 5,
+    category: 'planiranje',
+    title:
+      'Koliko vremena trošiš na planiranje zadataka, sastanaka i rasporeda?',
+    aiSavingsPercent: 0.25,
+    options: [
+      { label: 'Manje od 1 sata tjedno', minutes: 15 },
+      { label: '1-3 sata tjedno', minutes: 45 },
+      { label: '3-5 sati tjedno', minutes: 240 },
+      { label: '5-10 sati tjedno', minutes: 450 },
+      { label: 'Više od 10 sati tjedno', minutes: 720 },
+    ],
+  },
+  {
+    id: 6,
+    category: 'marketing',
+    title: 'Koliko vremena trošiš na pripremu objava ili marketing sadržaja?',
+    aiSavingsPercent: 0.4,
+    options: [
+      { label: 'Gotovo ništa, do 30 min tjedno', minutes: 15 },
+      { label: 'Manje od 1 sata tjedno, 30–60 min', minutes: 45 },
+      { label: '3-5 sati tjedno', minutes: 240 },
+      { label: '5-10 sati tjedno', minutes: 450 },
+      { label: 'Više od 10 sati tjedno', minutes: 720 },
+    ],
+  },
+]
+
+export const STORAGE_KEY = 'ht-ai-kalkulator'
+
+export function calculateResults(answers) {
+  const totalMinutes = answers.reduce((sum, a) => sum + a.minutes, 0)
+  const totalHoursWeekly = totalMinutes / 60
+  const totalHoursMonthly = totalHoursWeekly * 4
+
+  const savedMinutes = answers.reduce(
+    (sum, a, i) => sum + a.minutes * QUESTIONS[i].aiSavingsPercent,
+    0
+  )
+  const savedHoursMonthly = (savedMinutes / 60) * 4
+  const savedWorkDaysMonthly = (savedMinutes / 60 / 8) * 4
+
+  let dynamicPhrase = ''
+  if (savedWorkDaysMonthly >= 10) {
+    dynamicPhrase = 'više od dva tjedna'
+  } else if (savedWorkDaysMonthly >= 6) {
+    dynamicPhrase = 'više od tjedan dana'
+  } else if (savedWorkDaysMonthly >= 3) {
+    dynamicPhrase = 'skoro tjedan dana'
+  } else if (savedWorkDaysMonthly >= 1) {
+    dynamicPhrase = 'više od pola tjedna'
+  } else {
+    dynamicPhrase = 'nekoliko sati'
+  }
+
+  return {
+    totalHoursWeekly: Math.round(totalHoursWeekly * 10) / 10,
+    totalHoursMonthly: Math.round(totalHoursMonthly * 10) / 10,
+    savedHoursMonthly: Math.round(savedHoursMonthly * 10) / 10,
+    dynamicPhrase,
+  }
+}


### PR DESCRIPTION
Adds an interactive AI time-savings calculator for HT campaign. Renders as a centered popup on any article when ?ht-kalkulator=1 query param is present.

- 6-question flow with per-category AI savings calculation
- GTM events (start, per-question, complete)
- localStorage persistence (completed/dismissed)
- A11y: dialog role, ESC reset, keyboard nav, focus management
- HT magenta branding (#e20074), responsive desktop + mobile
- z-index 99 (below ads/softwall/REMP ticker)