### PR TITLE
fix: HT landing wide-screen layout + copy update

### DIFF
--- a/components/ht-landing/HtArticles.vue
+++ b/components/ht-landing/HtArticles.vue
@@ -1,7 +1,12 @@
 <template>
   <section class="ht-articles">
     <div class="ht-articles__inner">
-      <h2 class="ht-articles__title">Ovdje ide neki naslov</h2>
+      <div class="ht-articles__head">
+        <h2 class="ht-articles__title">Iza hypea</h2>
+        <p class="ht-articles__subtitle">
+          Što AI doista mijenja u različitim profesijama?
+        </p>
+      </div>
 
       <div class="ht-articles__grid">
         <article
@@ -92,6 +97,12 @@ export default {
   flex-direction: column;
   gap: 48px;
 }
+.ht-articles__head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
 .ht-articles__title {
   font-family: 'Inter', sans-serif;
   font-weight: 800;
@@ -100,6 +111,21 @@ export default {
   color: var(--ht-dark, #2e2b26);
   text-align: center;
   margin: 0;
+  /* Trim the line-height leading so the 20px gap is measured cap-to-baseline,
+     matching the Figma text-box-trim spec (cap / alphabetic). */
+  text-box-trim: trim-both;
+  text-box-edge: cap alphabetic;
+}
+.ht-articles__subtitle {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.3;
+  color: var(--ht-dark, #2e2b26);
+  text-align: center;
+  margin: 0;
+  text-box-trim: trim-both;
+  text-box-edge: cap alphabetic;
 }
 .ht-articles__grid {
   display: grid;
@@ -192,6 +218,12 @@ export default {
 @media (min-width: 1024px) {
   .ht-articles {
     padding: 80px 100px;
+  }
+  .ht-articles__inner {
+    gap: 56px;
+  }
+  .ht-articles__subtitle {
+    font-size: 22px;
   }
   .ht-articles__grid {
     grid-template-columns: repeat(4, 1fr);

--- a/components/ht-landing/HtHero.vue
+++ b/components/ht-landing/HtHero.vue
@@ -242,12 +242,19 @@ export default {
    hero stacks (image as a block below the content). */
 @media (min-width: 1280px) {
   .ht-hero {
+    /* The image keeps bleeding to the right viewport edge; only the text column
+       is anchored to the centered site frame (1240 content + 2x100 gutters), so
+       on wide screens it lines up with the rest of the page instead of hugging
+       the far-left edge. Below 1440 the gutter is 0 (design layout unchanged). */
+    --ht-hero-gutter: max(0px, (100% - 1440px) / 2);
     display: block;
     height: 666px;
     min-height: 666px;
   }
   .ht-hero__bar {
-    padding: 40px 100px;
+    /* Brand and badge both align to the centered 1240 site frame, so the top
+       line sits inside the container like the rest of the page. */
+    padding: 40px calc(100px + var(--ht-hero-gutter));
   }
   .ht-hero__media {
     position: absolute;
@@ -261,7 +268,7 @@ export default {
     position: absolute;
     z-index: 2;
     top: 50%;
-    left: 100px;
+    left: calc(100px + var(--ht-hero-gutter));
     transform: translateY(-50%);
     gap: 40px;
     max-width: 512px;

--- a/components/ht-landing/HtVideoCarousel.vue
+++ b/components/ht-landing/HtVideoCarousel.vue
@@ -2,9 +2,13 @@
   <section class="ht-videos">
     <div class="ht-videos__inner">
       <div class="ht-videos__header">
-        <h2 class="ht-videos__title">
-          Ovdje ide neki naslov za video serijale
-        </h2>
+        <div class="ht-videos__heading">
+          <h2 class="ht-videos__title">Koliko vremena zapravo štedi AI?</h2>
+          <p class="ht-videos__subtitle">
+            Usporedili smo svakodnevne zadatke s umjetnom inteligencijom i bez
+            nje.
+          </p>
+        </div>
         <div class="ht-videos__nav">
           <button
             class="ht-videos__arrow"
@@ -219,6 +223,11 @@ export default {
   gap: 16px;
   margin-bottom: 32px;
 }
+.ht-videos__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
 .ht-videos__title {
   font-family: 'Inter', sans-serif;
   font-weight: 800;
@@ -226,6 +235,20 @@ export default {
   line-height: 1.2;
   color: #ffffff;
   margin: 0;
+  /* Trim the line-height leading so the 20px gap is measured cap-to-baseline,
+     matching the Figma text-box-trim spec (cap / alphabetic). */
+  text-box-trim: trim-both;
+  text-box-edge: cap alphabetic;
+}
+.ht-videos__subtitle {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.4;
+  color: #ffffff;
+  margin: 0;
+  text-box-trim: trim-both;
+  text-box-edge: cap alphabetic;
 }
 .ht-videos__nav {
   /* Mobile/tablet: no page switcher — cards are swipe-scrollable. */
@@ -395,10 +418,13 @@ export default {
     padding: 94px 100px;
   }
   .ht-videos__header {
-    margin-bottom: 48px;
+    margin-bottom: 40px;
   }
   .ht-videos__title {
     font-size: 32px;
+  }
+  .ht-videos__subtitle {
+    font-size: 22px;
   }
   .ht-videos__nav {
     display: flex;

--- a/pages/ht-ai-landing.vue
+++ b/pages/ht-ai-landing.vue
@@ -144,7 +144,11 @@ export default {
   --ht-dark-hover: #1c1a17;
 
   width: 100%;
-  background: #ffffff;
+  /* Fills at least the full viewport so the Telegram theme's body background
+     never shows below the footer (e.g. when zoomed out). The color matches the
+     footer so the area beneath it blends in. Scoped to this page's wrapper. */
+  min-height: 100vh;
+  background: #f5f5f5;
   font-family: 'Inter', 'Barlow', sans-serif;
 }
 </style>


### PR DESCRIPTION
Follow-up to the HT AI landing (#184), based on Telegram feedback and the updated Figma.

### Changes
- **Hero on wide screens**: image keeps bleeding to the right viewport edge, while the text column, brand and badge are anchored to the centered 1240 site frame so they no longer drift to the far-left edge. Below 1440px the layout is unchanged.
- **Body background**: the page wrapper now fills at least the viewport (footer color), so the Telegram theme background no longer shows below the footer when zoomed out.
- **Copy + subtitles**: real Figma copy for the Articles ("Iza hypea") and Video ("Koliko vremena zapravo štedi AI?") sections, each with a subtitle. `text-box-trim` makes the title/subtitle spacing match the design.

### Notes
- Placeholder copy + `#` links (articles 3/4, video cards, hero lead) remain intentional, pending final HT content.