### PR TITLE
fix(ht-ai-landing): Inter umjesto Barlowa u sekciji članaka

### DIFF
--- a/components/ht-landing/HtArticles.vue
+++ b/components/ht-landing/HtArticles.vue
@@ -165,7 +165,7 @@ export default {
   gap: 18px;
 }
 .ht-article-card__heading {
-  font-family: 'Barlow', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 600;
   font-size: 20px;
   line-height: 1.25;
@@ -179,7 +179,7 @@ export default {
   overflow: hidden;
 }
 .ht-article-card__excerpt {
-  font-family: 'Barlow', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 400;
   font-size: 16px;
   line-height: 1.375;


### PR DESCRIPTION
## Što
Sekcija članaka na HT AI landingu: naslov kartice i excerpt prebačeni s Barlowa na Inter, prema Figmi (JaRKrWfzXk8hde2EQrmt3c, Articles Section).

- `.ht-article-card__heading`: Barlow 600 -> Inter 600 (Figma: Inter SemiBold 20)
- `.ht-article-card__excerpt`: Barlow 400 -> Inter 400 (Figma: Inter Regular 16)

Naslov sekcije, podnaslov i gumb su već bili Inter. Inter weights su već učitani na stranici, nema novih font requestova.

## Provjera
- Lokalno (nuxt dev): getComputedStyle potvrđuje Inter 600/20px na naslovu kartice i Inter 400/16px na excerptu
- Vizualno uspoređeno s Figma dizajnom sekcije članaka

ClickUp: CU-86ca6p717