### PR TITLE
feat(ht-kalkulator): GTM eventovi - view/dismiss/CTA + kontekst članka

### DIFF
--- a/components/ht-kalkulator/HtKalkulator.vue
+++ b/components/ht-kalkulator/HtKalkulator.vue
@@ -72,6 +72,15 @@ export default {
     currentQuestion() {
       return this.questions[this.answers.length] || this.questions[0]
     },
+    // Spread into every GTM push so reports can split the funnel by where
+    // the kalkulator ran (landing vs. curated article, and which article).
+    trackingContext() {
+      return {
+        kalkulator_source:
+          this.$route.name === 'ht-ai-landing' ? 'landing' : 'article',
+        kalkulator_article_slug: this.$route.params.slug || null,
+      }
+    },
   },
   mounted() {
     const stored = this.getStoredState()
@@ -79,6 +88,7 @@ export default {
       this.visible = false
       return
     }
+    this.$gtm.push({ event: 'ht-kalkulator-view', ...this.trackingContext })
     this.$nextTick(() => {
       if (this.$refs.wrapper) {
         this.$refs.wrapper.focus()
@@ -90,7 +100,7 @@ export default {
       this.state = 'questions'
       this.answers = []
       this.results = null
-      this.$gtm.push({ event: 'ht-kalkulator-start' })
+      this.$gtm.push({ event: 'ht-kalkulator-start', ...this.trackingContext })
     },
 
     handleAnswer(answer) {
@@ -100,6 +110,9 @@ export default {
         event: 'ht-kalkulator-question',
         kalkulator_question: answer.questionId,
         kalkulator_answer_minutes: answer.minutes,
+        kalkulator_answer_label: answer.label,
+        kalkulator_step: this.answers.length,
+        ...this.trackingContext,
       })
 
       if (this.answers.length === this.questions.length) {
@@ -125,10 +138,17 @@ export default {
         kalkulator_total_hours_weekly: this.results.totalHoursWeekly,
         kalkulator_total_hours_monthly: this.results.totalHoursMonthly,
         kalkulator_savings_hours_monthly: this.results.savedHoursMonthly,
+        ...this.trackingContext,
       })
     },
 
     handleDismiss() {
+      this.$gtm.push({
+        event: 'ht-kalkulator-dismiss',
+        kalkulator_state: this.state,
+        kalkulator_step: this.answers.length,
+        ...this.trackingContext,
+      })
       this.setStoredState('dismissed')
       this.visible = false
     },

--- a/pages/ht-ai-landing.vue
+++ b/pages/ht-ai-landing.vue
@@ -3,10 +3,10 @@
     <ht-hero
       :value="heroValue"
       :decimals="heroDecimals"
-      @open-kalkulator="openKalkulator"
+      @open-kalkulator="openKalkulator('hero')"
     />
     <ht-articles :articles="articles" />
-    <ht-kalkulator-cta @open-kalkulator="openKalkulator" />
+    <ht-kalkulator-cta @open-kalkulator="openKalkulator('mid')" />
     <ht-video-carousel />
     <ht-landing-footer />
 
@@ -57,7 +57,11 @@ export default {
     onKalkulatorCompleted(results) {
       this.applyResult(results)
     },
-    openKalkulator() {
+    openKalkulator(location) {
+      this.$gtm.push({
+        event: 'ht-kalkulator-cta-click',
+        kalkulator_cta_location: location,
+      })
       // The widget gates itself via localStorage (dismissed/completed). On this
       // landing the CTA must reliably reopen it, so clear the flag and remount.
       try {


### PR DESCRIPTION
## Što
Analytics za HT AI Kalkulator u postojećem $gtm.push house styleu, bez novih ovisnosti.

**Obogaćeni postojeći eventovi** (imena nepromijenjena):
- `ht-kalkulator-question`: + `kalkulator_answer_label`, `kalkulator_step` (1-6)
- `ht-kalkulator-start` / `ht-kalkulator-complete`: + kontekst (dolje)

**Novi eventovi**:
- `ht-kalkulator-view`: popup prikazan (denominator funnela)
- `ht-kalkulator-dismiss`: + `kalkulator_state` (intro/questions/result) i `kalkulator_step` za drop-off analizu
- `ht-kalkulator-cta-click`: + `kalkulator_cta_location` (hero/mid) na landingu

**Kontekst na svim kalkulator eventovima** (computed `trackingContext`): `kalkulator_source` (landing/article) + `kalkulator_article_slug`, za breakdown po kuriranim člancima iz #189.

Result CTA event namjerno izostavljen: result CTA je još placeholder, čeka HT dizajn.

## Provjera (lokalno, presretanjem $gtm.push poziva, GTM je u dev modu disabled)
Cijeli funnel na landingu: `cta-click(hero)` → `view(landing)` → `start` → 6× `question` (s labelom, minutama i stepom) → `complete` (s totalima) → `dismiss(result, step 6)`. Na kuriranom članku: eventi nose `kalkulator_source: article` + točan slug. ESLint čist.

GTM/GA4 strana (triggeri, varijable, tagovi, conversion, funnel) ide u GTM container, specifikacija na CU tasku.

## Napomena
Stackano na #189 (base je ta grana, dijele `pages/ht-ai-landing.vue`). Nakon merga #189 GitHub automatski retargeta na dev.

ClickUp: CU-86ca6crv4