### PR TITLE
feat: add admin toggle to move Telesport to top of homepage

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -136,6 +136,10 @@
         </div>
       </div>
     </div>
+    <!-- Sport (pinned to top via WP admin: Naslovnica > Telesport na vrh) -->
+    <div v-if="telesportTop" class="full relative">
+      <sport></sport>
+    </div>
     <!-- Intro block: G1 + comments -->
     <div v-if="posts.length" class="full relative">
       <div class="container flex relative stretch cantha-intro-block">
@@ -374,7 +378,7 @@
       </div>
     </client-only>
     <!-- Sport -->
-    <div class="full relative">
+    <div v-if="!telesportTop" class="full relative">
       <sport></sport>
     </div>
     <!-- Super1 -->
@@ -486,8 +490,11 @@
 <script>
 export default {
   async fetch() {
-    await this.$store.dispatch('featured/pullPosts')
-    await this.$store.dispatch('featured/pullBreaks')
+    await Promise.all([
+      this.$store.dispatch('featured/pullPosts'),
+      this.$store.dispatch('featured/pullBreaks'),
+      this.$store.dispatch('homepageLayout/fetch'),
+    ])
     // Pre-fetch gifts for logged-in users
     if (process.client && this.$store.state.user.token) {
       this.$store.dispatch('gifts/getUserGifts')
@@ -505,6 +512,9 @@ export default {
     },
     canLogIn() {
       return this.$store.getters['user/canLogIn']
+    },
+    telesportTop() {
+      return this.$store.state.homepageLayout.telesportTop
     },
     posts() {
       return this.$store.state.featured.posts || []

--- a/store/homepageLayout.js
+++ b/store/homepageLayout.js
@@ -1,0 +1,26 @@
+export const state = () => ({
+  telesportTop: false,
+})
+
+export const mutations = {
+  set(state, data) {
+    state.telesportTop = !!data.telesportTop
+  },
+}
+
+export const actions = {
+  fetch({ commit }) {
+    return new Promise((resolve) => {
+      this.$axios
+        .get('/api/homepage-settings')
+        .then((res) => {
+          commit('set', { telesportTop: res.data?.telesport_top })
+          resolve()
+        })
+        .catch(() => {
+          // Layout flag is non-critical: keep default order on failure
+          resolve()
+        })
+    })
+  },
+}


### PR DESCRIPTION
Reads global telesport_top flag from /api/homepage-settings and renders the Sport block at the top of the homepage when enabled.