### PR TITLE
fix(ht-kalkulator): keep close button reachable on tall result screen

### DIFF
--- a/components/ht-kalkulator/HtKalkulator.vue
+++ b/components/ht-kalkulator/HtKalkulator.vue
@@ -232,15 +232,23 @@ export default {
   bottom: 0;
   z-index: 99;
   display: flex;
-  align-items: center;
   justify-content: center;
   padding: 20px;
-  pointer-events: none;
+  /* Scroll when the modal (e.g. the result screen) is taller than the viewport.
+     Without this, align-items:center pushed the dialog top, and the close
+     button at top:12px, above the viewport with no way to scroll back. */
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  pointer-events: auto;
 }
 
 .ht-kalkulator {
   width: 100%;
   max-width: 640px;
+  /* margin:auto centers the dialog when it fits, but unlike align-items:center
+     it lets the overlay scroll to the very top when the content is taller than
+     the viewport, keeping the close button reachable. */
+  margin: auto;
   background: #fff;
   pointer-events: auto;
   border-radius: 16px;


### PR DESCRIPTION
The kalkulator overlay centered the dialog with align-items:center and had no scroll. When the result screen was taller than the viewport (common on Mac laptops), the top of the dialog, including the close button at top:12px, was pushed above the viewport with no way to scroll back, so the modal could not be closed (only "Ponovi kalkulator" was reachable).

Drop align-items:center, add overflow-y:auto on the overlay and margin:auto on the dialog: it stays centered when it fits and scrolls to the very top when it does not, keeping the close button reachable.