### PR TITLE
fix(dotmetrics): remove redundant door.js preloads (86cam4w8q)

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,9 +37,14 @@ export default {
                 href: 'https://twitter.com/TelegramHR',
             },
             { rel: 'dns-prefetch', href: 'https://script.dotmetrics.net' },
-            { rel: 'preconnect', href: 'https://script.dotmetrics.net', crossorigin: true },
-            { rel: 'preload', href: 'https://script.dotmetrics.net/door.js?id=15854', as: 'script' },
-            { rel: 'preload', href: 'https://script.dotmetrics.net/door.js?id=1182', as: 'script' },
+            { rel: 'preconnect', href: 'https://script.dotmetrics.net' },
+            // NOTE: static door.js preloads removed. The dotmetrics.client.js plugin
+            // dynamically injects exactly one path-based door.js per URL (id 1182 default,
+            // 15854 news, 15855 kultura/zivot, 4136 super1, 1175 sport). Two static preloads
+            // (15854 + 1182) fired on every page produced a second, always-dead door.js
+            // request, and on kultura/super1/sport paths BOTH preloads were dead. Removing
+            // both guarantees a single door.js request per URL. preconnect above keeps the
+            // connection warm so the plugin-injected script still loads promptly.
             // DNS prefetch for ad networks
             { rel: 'dns-prefetch', href: '//securepubads.g.doubleclick.net' },
             { rel: 'dns-prefetch', href: '//pagead2.googlesyndication.com' },


### PR DESCRIPTION
## Kontekst
Ipsos (Alen Šabanović) preko Petre Velijević prijavio više DotMetrics mrežnih zahtjeva po URL-u (SupportPal #920 / #2453248).

## Promjena
Uklonjeni suvišni statički `<link rel="preload">` za DotMetrics `door.js` iz nuxt.config.js. Skripta se ionako učitava dinamički, pa je preload uzrokovao dupli mrežni zahtjev.

## Test plan
- [ ] Provjeriti na stagingu da se `door.js` učita samo jednom (Network tab, filter door.js)
- [ ] Potvrditi da DotMetrics measurement i dalje radi (nema regresije u trackingu)

CU: https://app.clickup.com/t/86cam4w8q