### PR TITLE
feat: load custom fonts only on pages that use them

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -26,6 +26,22 @@
     font-family: "termina", sans-serif !important;
 }
 
+.has-aukio-font-family {
+    font-family: "aukio-std", sans-serif !important;
+}
+
+.has-degular-font-family {
+    font-family: "degular", sans-serif !important;
+}
+
+.has-inter-font-family {
+    font-family: "Inter", sans-serif !important;
+}
+
+.has-clash-display-font-family {
+    font-family: "Clash Display", sans-serif !important;
+}
+
 @font-face {
     font-family: 'Bai Jamjuree';
     font-style: normal;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -62,10 +62,6 @@ export default {
             },
             {
                 rel: 'stylesheet',
-                href: 'https://use.typekit.net/rhj2chq.css',
-            },
-            {
-                rel: 'stylesheet',
                 href: '/wp-content/themes/telegram2-desktop/assets/fonts/nyght/nyght.css',
             },
         ],

--- a/pages/_category/_slug.vue
+++ b/pages/_category/_slug.vue
@@ -1423,6 +1423,7 @@ import BusinessWidget from '~/components/Elements/BusinessWidget.vue'
 import HtKalkulator from '~/components/ht-kalkulator/HtKalkulator.vue'
 import MatchScoreboard from '~/components/liveblog/MatchScoreboard.vue'
 import { HT_CAMPAIGN_ARTICLE_SLUGS } from '~/store/ht-kalkulator/articles'
+import { customFontLinks } from '~/utils/customFonts'
 
 const widgetMap = {
   a1: 'A1Widget',
@@ -2706,6 +2707,7 @@ export default {
         rel: 'shortlink',
         href: `https://www.telegram.hr/l/${this.post.id}`,
       },
+      ...customFontLinks(this.post),
     ]
     let script = [
       {

--- a/pages/fotogalerije/_category/_slug.vue
+++ b/pages/fotogalerije/_category/_slug.vue
@@ -81,6 +81,8 @@
 </template>
 
 <script>
+import { customFontLinks } from '~/utils/customFonts'
+
 export default {
   name: 'Slug',
   scrollToTop: true,
@@ -231,6 +233,7 @@ export default {
           rel: 'canonical',
           href: this.post.social.path,
         },
+        ...customFontLinks(this.post),
       ],
     }
   },

--- a/pages/soping-vodic/_.vue
+++ b/pages/soping-vodic/_.vue
@@ -215,6 +215,7 @@
 
 <script>
 import { Portal } from '@linusborg/vue-simple-portal'
+import { customFontLinks } from '~/utils/customFonts'
 export default {
   name: 'Slug',
   components: { Portal },
@@ -443,6 +444,7 @@ export default {
         rel: 'canonical',
         href: this.post.social.path,
       },
+      ...customFontLinks(this.post),
     ]
     const fbPaywall = {
       none: 'metered',

--- a/pages/specijal/_specijal.vue
+++ b/pages/specijal/_specijal.vue
@@ -54,6 +54,8 @@
 </template>
 
 <script>
+import { customFontLinks } from '~/utils/customFonts'
+
 export default {
   name: 'SpecijalIndex',
   async fetch() {
@@ -241,6 +243,7 @@ export default {
           rel: 'canonical',
           href: 'https://www.telegram.hr' + this.$route.fullPath,
         },
+        ...customFontLinks(this.post),
       ],
     }
   },

--- a/pages/stranica/_page.vue
+++ b/pages/stranica/_page.vue
@@ -22,6 +22,8 @@
 </template>
 
 <script>
+import { customFontLinks } from '~/utils/customFonts'
+
 export default {
   name: 'Page',
   async fetch() {
@@ -104,6 +106,7 @@ export default {
         },
       ],
       link: [
+        ...customFontLinks(this.post),
         {
           hid: 'canonical',
           rel: 'canonical',

--- a/utils/customFonts.js
+++ b/utils/customFonts.js
@@ -1,0 +1,64 @@
+/*
+ * Editor-selectable custom fonts whose stylesheets are loaded per page,
+ * only when the rendered content actually uses them.
+ *
+ * Slugs must match the `has-<slug>-font-family` utility classes that the
+ * WordPress editor stamps on blocks (registered in the telegram-desktop
+ * theme, functions-shared.php) and the matching classes in assets/style.css.
+ */
+const CUSTOM_FONTS = [
+  {
+    slug: 'termina',
+    href: 'https://use.typekit.net/rhj2chq.css',
+  },
+  {
+    slug: 'aukio',
+    href: 'https://use.typekit.net/wpf5opw.css',
+  },
+  {
+    slug: 'degular',
+    href: 'https://use.typekit.net/ijo6mdc.css',
+  },
+  {
+    slug: 'inter',
+    href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
+  },
+  {
+    slug: 'clash-display',
+    href: 'https://api.fontshare.com/v2/css?f[]=clash-display@200,300,400,500,600,700&display=swap',
+  },
+]
+
+/*
+ * Fields that carry CSS/JS rather than editor content. WordPress global
+ * styles (post.styles) define `.has-<slug>-font-family` rules for EVERY
+ * registered font on every post, so scanning them would load every font
+ * everywhere.
+ */
+const NON_CONTENT_KEYS = ['styles', 'additional_styles', 'additional_scripts']
+
+/**
+ * Head link objects for the custom fonts referenced in the post's content.
+ * Scans every field of the post (content, perex, live updates, captions...)
+ * except the CSS/JS ones above.
+ *
+ * @param {object} post
+ * @returns {Array<{hid: string, rel: string, href: string}>}
+ */
+export function customFontLinks(post) {
+  if (!post) {
+    return []
+  }
+
+  const html = JSON.stringify(post, (key, value) =>
+    NON_CONTENT_KEYS.includes(key) ? undefined : value
+  )
+
+  return CUSTOM_FONTS.filter((font) =>
+    html.includes(`has-${font.slug}-font-family`)
+  ).map((font) => ({
+    hid: `font-${font.slug}`,
+    rel: 'stylesheet',
+    href: font.href,
+  }))
+}


### PR DESCRIPTION
## Summary

- Adds four new editor-selectable fonts: **Aukio** (Typekit `wpf5opw`), **Degular** (Typekit `ijo6mdc`), **Inter** (Google Fonts, all styles) and **Clash Display** (Fontshare, all styles)
- Font kit stylesheets are no longer loaded globally: every page that renders WP post HTML (article + section wrappers, stranica, šoping vodič, fotogalerije, specijal) injects a kit `<link>` in `head()` only when the post content actually contains that font's `has-<slug>-font-family` class
- **Termina's global Typekit link is removed from `nuxt.config.js`** and migrated to the same conditional mechanism — it now loads only on articles that use it
- New `utils/customFonts.js` is the single source of truth (slug → stylesheet URL)

## Notes

- The WP API embeds global-styles CSS in `post.styles`, which names every registered font on every post — the matcher deliberately skips `styles` / `additional_styles` / `additional_scripts` so only real content usage triggers a load
- Companion PR in `telegram-desktop` registers the fonts in the editor
- Aukio's kit ships weight 400 only; Degular 400/600/700 + italic

## Test plan

- [x] Homepage / listing pages make no Typekit, Fontshare or Inter requests (Gloock + Nyght unchanged)
- [x] Articles and stranica pages without custom fonts get no font `<link>` (verified on dev server against live API)
- [x] Helper unit-tested: content using a font loads exactly that kit; `post.styles` mentions are ignored; nested live-blog updates detected
- [ ] After deploy: spot-check an existing published article that uses Termina renders correctly