### PR TITLE
fix: detect classic-editor inline font styles in custom font loader

### DIFF
--- a/utils/customFonts.js
+++ b/utils/customFonts.js
@@ -3,28 +3,36 @@
  * only when the rendered content actually uses them.
  *
  * Slugs must match the `has-<slug>-font-family` utility classes that the
- * WordPress editor stamps on blocks (registered in the telegram-desktop
- * theme, functions-shared.php) and the matching classes in assets/style.css.
+ * block editor stamps on blocks (registered in the telegram-desktop theme,
+ * functions-shared.php) and the matching classes in assets/style.css.
+ * `family` is the CSS family name the classic editor (TinyMCE) writes as
+ * an inline style (`<span style="font-family: aukio-std, ...">`) — as a
+ * regex source, since inline usage carries no class to match on.
  */
 const CUSTOM_FONTS = [
   {
     slug: 'termina',
+    family: 'termina',
     href: 'https://use.typekit.net/rhj2chq.css',
   },
   {
     slug: 'aukio',
+    family: 'aukio-std',
     href: 'https://use.typekit.net/wpf5opw.css',
   },
   {
     slug: 'degular',
+    family: 'degular',
     href: 'https://use.typekit.net/ijo6mdc.css',
   },
   {
     slug: 'inter',
+    family: 'Inter\\b',
     href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
   },
   {
     slug: 'clash-display',
+    family: 'Clash Display',
     href: 'https://api.fontshare.com/v2/css?f[]=clash-display@200,300,400,500,600,700&display=swap',
   },
 ]
@@ -54,8 +62,14 @@ export function customFontLinks(post) {
     NON_CONTENT_KEYS.includes(key) ? undefined : value
   )
 
-  return CUSTOM_FONTS.filter((font) =>
-    html.includes(`has-${font.slug}-font-family`)
+  // Match the block editor's utility class or a classic-editor inline
+  // declaration where the font is the first family listed. The character
+  // class only lets whitespace, quotes and JSON escapes sit between
+  // `font-family:` and the name, so `var(--wp--preset...)` never matches.
+  return CUSTOM_FONTS.filter(
+    (font) =>
+      html.includes(`has-${font.slug}-font-family`) ||
+      new RegExp(`font-family:[\\s"'\\\\]*${font.family}`, 'i').test(html)
   ).map((font) => ({
     hid: `font-${font.slug}`,
     rel: 'stylesheet',


### PR DESCRIPTION
## Summary

Follow-up to #220. On `dev.telegram.hr/super1/life/font-testiranje/` the fonts applied via the **classic editor (TinyMCE) font dropdown** did not load: TinyMCE saves inline `style="font-family: aukio-std, sans-serif;"` spans, while the loader only matched the `has-<slug>-font-family` classes the **block editor** typography picker adds. Gloock/Nyght still worked because they load globally — hence "only Gloock and Nyght work".

`customFontLinks()` now also matches inline `font-family:` declarations (first-listed family, whitespace/quotes allowed after the colon):

- `font-family: aukio-std, ...` / `degular` / `termina` / `'Clash Display'` / `Inter`
- `Inter` is word-bounded and only matched inside a `font-family:` declaration, so prose ("Inter Milan"), `inherit`, and `Interstate` cannot false-positive
- `var(--wp--preset--font-family--*)` references and the `post.styles` global-styles field still never trigger a load

## Test plan

- [x] Unit-tested against the exact markup of the font-testiranje article (all 5 fonts detected)
- [x] Block-editor class detection unchanged
- [x] False-positive guards: "Inter Milan" prose, `inherit`, `Interstate`, preset `var()`, `post.styles`
- [ ] After deploy to dev: `curl -s https://dev.telegram.hr/super1/life/font-testiranje/ | grep -o 'data-hid="font-[a-z-]*"'` should list all five fonts and the page should render them