### PR TITLE
fix: load Funding Choices CMP standalone in head

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -65,7 +65,28 @@ export default {
                 href: '/wp-content/themes/telegram2-desktop/assets/fonts/nyght/nyght.css',
             },
         ],
-        script: [{
+        script: [
+            // Google Privacy & messaging (Funding Choices) — must stay first.
+            // Loaded standalone rather than as a downstream fetch of adsbygoogle.js
+            // so that __tcfapi exists at parse time instead of ~1.8s after
+            // hydration, and so consent no longer depends on the ad tag loading
+            // (premium users, ad blockers, in-app browsers).
+            {
+                hid: 'googlefc',
+                src: 'https://fundingchoicesmessages.google.com/i/pub-2317149376955370?ers=1',
+                async: true,
+            },
+            {
+                // Signals to Google's ad tags that Funding Choices is on the page.
+                // Required for ad block detection to work.
+                hid: 'googlefc-present',
+                innerHTML: '(function() {function signalGooglefcPresent() {if (!window.frames["googlefcPresent"]) {' +
+                    'if (document.body) {const iframe = document.createElement("iframe"); ' +
+                    'iframe.style = "width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;"; ' +
+                    'iframe.style.display = "none"; iframe.name = "googlefcPresent"; document.body.appendChild(iframe);} ' +
+                    'else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();',
+            },
+            {
                 hid: 'coral',
                 src: 'https://talk.telegram.hr/assets/js/embed.js',
                 async: false,
@@ -124,6 +145,7 @@ export default {
         __dangerouslyDisableSanitizersByTagID: {
             remplib: ['innerHTML'],
             didomi: ['innerHTML'],
+            'googlefc-present': ['innerHTML'],
         },
     },
 


### PR DESCRIPTION
The CMP only reached the page as a downstream fetch of adsbygoogle.js, which plugins/adsense.client.js appends after hydration and skips for premium users entirely.

Measured on production: __tcfapi only appeared ~1800ms in, well after plugins/dotmetrics.client.js had already loaded door.js via its 500ms "no CMP present" fallback. Dotmetrics therefore initialised in a page where the consent API did not yet exist and recorded a pageview (hit.gif) ~8s before the user consented, and ~360ms before the consent dialog was even rendered.

Load the Privacy & messaging tag directly, first in head, so __tcfapi exists at parse time and consent no longer depends on the ad tag loading at all. This also gives a CMP to premium users and to anyone blocking adsbygoogle.js, neither of whom had one before.