### PR TITLE
fix: reload page after consent decision (Dotmetrics NCS mode)

### DIFF
--- a/plugins/gtm.client.js
+++ b/plugins/gtm.client.js
@@ -27,9 +27,16 @@ export default ({ app }) => {
           ad_personalization: data.purpose.consents[4] ? 'granted' : 'denied',
         })
         if (data.eventStatus === 'useractioncomplete') {
-          // Reload removed: consent update is sufficient for GA4.
-          // Reload was causing document.referrer to become self-referral,
-          // breaking UTM campaign attribution from external sites.
+          // Dotmetrics' door.js decides consent once, at load time: it latches
+          // on cmpuishown (lr=true) and calls removeEventListener, so it never
+          // re-evaluates when the user later consents and stays in anonymous
+          // NCS mode for the rest of the page view. Reloading is the only way
+          // to re-run its checkTCF(). Same applies to any other vendor script
+          // already initialised under the pre-consent state.
+          // Delay so the CMP finishes persisting the TC string first.
+          setTimeout(() => {
+            window.location.reload()
+          }, 300)
         }
       }),
   })


### PR DESCRIPTION
Dotmetrics' door.js resolves consent exactly once, at load time: checkTCF() latches lr=true on cmpuishown and calls removeEventListener, so a later useractioncomplete is ignored. A user who consents therefore stays in anonymous NCS mode (hit.gif with c=false, no domain cookie, no Adex) for the remainder of that page view.

Now that the CMP loads from head, door.js sees cmpuishown on first visit and takes that latched non-consent path, so a reload is required to re-run checkTCF. Reload only on useractioncomplete, which fires on explicit user action and never on a plain page load, so this cannot loop.