### PR TITLE
fix: preserve document.referrer across the consent reload

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -66,7 +66,24 @@ export default {
             },
         ],
         script: [
-            // Google Privacy & messaging (Funding Choices) — must stay first.
+            // Restore the referrer across the post-consent reload (see
+            // plugins/gtm.client.js). location.reload() makes document.referrer
+            // self-referential, and because Consent Mode starts denied the GA4
+            // session only begins on the reloaded page — so the session would
+            // take telegram.hr as its own source. Dotmetrics (rurl), Marfeel and
+            // Gemius read the same property, so restoring it fixes all at once.
+            // Must run before anything reads document.referrer, hence first.
+            {
+                hid: 'referrer-restore',
+                innerHTML: '(function(){try{var k="cmp_ref";var raw=window.sessionStorage.getItem(k);' +
+                    'if(raw===null){return}window.sessionStorage.removeItem(k);' +
+                    'var d=JSON.parse(raw);if(!d||typeof d.r!=="string"){return}' +
+                    'if(Date.now()-d.t>60000){return}' +
+                    'Object.defineProperty(document,"referrer",{configurable:true,get:function(){return d.r}});' +
+                    '}catch(e){}})();',
+            },
+            // Google Privacy & messaging (Funding Choices) — must stay ahead of
+            // the ad and analytics tags.
             // Loaded standalone rather than as a downstream fetch of adsbygoogle.js
             // so that __tcfapi exists at parse time instead of ~1.8s after
             // hydration, and so consent no longer depends on the ad tag loading
@@ -146,6 +163,7 @@ export default {
             remplib: ['innerHTML'],
             didomi: ['innerHTML'],
             'googlefc-present': ['innerHTML'],
+            'referrer-restore': ['innerHTML'],
         },
     },
 

--- a/plugins/gtm.client.js
+++ b/plugins/gtm.client.js
@@ -33,6 +33,15 @@ export default ({ app }) => {
           // NCS mode for the rest of the page view. Reloading is the only way
           // to re-run its checkTCF(). Same applies to any other vendor script
           // already initialised under the pre-consent state.
+          // Stash the real referrer so the head script can restore it after
+          // the reload. Store even when empty: direct traffic would otherwise
+          // come back as a telegram.hr self-referral, which is worse than blank.
+          try {
+            window.sessionStorage.setItem(
+              'cmp_ref',
+              JSON.stringify({ r: document.referrer || '', t: Date.now() })
+            )
+          } catch (e) {}
           // Delay so the CMP finishes persisting the TC string first.
           setTimeout(() => {
             window.location.reload()


### PR DESCRIPTION
window.location.reload() makes document.referrer self-referential (verified on staging: https://www.google.com/ -> https://staging.telegram.hr/, and reproduced locally). Because Consent Mode starts denied, no _ga cookie exists on the first load, so the GA4 session only really begins on the reloaded page — exactly when the referrer is self-referential. The session then takes telegram.hr as its own source, which is what 15838a8d originally observed.

Stash the real referrer before reloading and restore it from an inline head script that runs before anything can read the property. Dotmetrics (rurl in the SiteEvent payload), Marfeel and Gemius read the same property, so this fixes all of them without a GTM container change.

Empty referrers are stashed and restored too: direct traffic would otherwise come back as a self-referral, which is worse than blank. The stash is single-use and expires after 60s.

Verified against the rendered markup: baseline reproduces the self-referral, google.com and empty referrers restore correctly, and stale or malformed stashes are ignored without crashing.